### PR TITLE
Fix the wrong path "/metrics"

### DIFF
--- a/lib/yabeda/prometheus/mmap/exporter.rb
+++ b/lib/yabeda/prometheus/mmap/exporter.rb
@@ -16,7 +16,7 @@ module Yabeda
         class << self
           # Allows to use middleware as standalone rack application
           def call(env)
-            @app ||= new(NOT_FOUND_HANDLER, path: '/metrics')
+            @app ||= new(NOT_FOUND_HANDLER, path: '/')
             @app.call(env)
           end
 


### PR DESCRIPTION
Fix getting "Not Found" when mounting `Yabeda::Prometheus::Exporter` on the endpoint `/metrics` in Rails.