### PR TITLE
Allow to disable requests log

### DIFF
--- a/lib/yabeda/prometheus/mmap/exporter.rb
+++ b/lib/yabeda/prometheus/mmap/exporter.rb
@@ -34,7 +34,7 @@ module Yabeda
 
           def rack_app(exporter = self, path: '/metrics')
             ::Rack::Builder.new do
-              use ::Rack::CommonLogger
+              use ::Rack::CommonLogger if ENV['PROMETHEUS_EXPORTER_LOG_REQUESTS'] != 'false'
               use ::Rack::ShowExceptions
               use exporter, path: path
               run NOT_FOUND_HANDLER


### PR DESCRIPTION
We have dozens of puma workes that produce a ton of log entries every few seconds.

With this change, we can disable [`Rack::CommonLogger`](https://github.com/rack/rack/blob/master/lib/rack/common_logger.rb) by `PROMETHEUS_EXPORTER_LOG_REQUESTS=false` environment variable.