### PR TITLE
Fix gauge aggregation

### DIFF
--- a/lib/yabeda/prometheus/mmap/adapter.rb
+++ b/lib/yabeda/prometheus/mmap/adapter.rb
@@ -35,7 +35,8 @@ module Yabeda
           registry.gauge(
             build_name(metric),
             metric.comment,
-            build_tags(metric.tags)
+            build_tags(metric.tags),
+            metric.aggregation || :all
           )
         end
 

--- a/lib/yabeda/prometheus/mmap/adapter.rb
+++ b/lib/yabeda/prometheus/mmap/adapter.rb
@@ -36,7 +36,7 @@ module Yabeda
             build_name(metric),
             metric.comment,
             build_tags(metric.tags),
-            metric.aggregation || :all
+            gauge_aggregation_mode(metric.aggregation)
           )
         end
 
@@ -84,6 +84,21 @@ module Yabeda
                       tags: %i[], unit: :seconds,
                       buckets: [0.001, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10],
                       comment: 'Time required to render all metrics in Prometheus format'
+          end
+        end
+
+        private
+
+        def gauge_aggregation_mode(yabeda_mode)
+          case yabeda_mode
+          when nil, :most_recent # TODO: Switch to most_recent when supported: https://gitlab.com/gitlab-org/ruby/gems/prometheus-client-mmap/-/issues/36
+            :all
+          when :min, :max, :all, :liveall
+            yabeda_mode
+          when :sum
+            :livesum
+          else
+            raise ArgumentError, "Unsupported gauge aggregation mode #{yabeda_mode.inspect}"
           end
         end
 

--- a/spec/yabeda/prometheus/mmap_spec.rb
+++ b/spec/yabeda/prometheus/mmap_spec.rb
@@ -13,7 +13,8 @@ RSpec.describe Yabeda::Prometheus::Mmap do
 
       gauge :gauge,
             comment: 'Gauge',
-            tags: [:gtag]
+            tags: [:gtag],
+            aggregation: :max
 
       histogram :histogram,
                 comment: 'Histogram',
@@ -40,6 +41,15 @@ RSpec.describe Yabeda::Prometheus::Mmap do
       expect(Yabeda.test_gauge.values).to eq(
         { { gtag: :'gtag-value' } => 123 }
       )
+    end
+
+    it 'passes aggregation to multiprocess_mode' do
+      expect(
+        Yabeda
+        .adapters[:prometheus].registry
+        .instance_variable_get(:@metrics)[:test_gauge]
+        .instance_variable_get(:@multiprocess_mode)
+      ).to eq(:max)
     end
   end
 

--- a/spec/yabeda/prometheus/mmap_spec.rb
+++ b/spec/yabeda/prometheus/mmap_spec.rb
@@ -32,9 +32,19 @@ RSpec.describe Yabeda::Prometheus::Mmap do
       expect(Yabeda.test_counter.values).to eq(
         { { ctag: :'ctag-value' } => 1 }
       )
+    end
+  end
+
+  context 'gauge' do
+    it do
       expect(Yabeda.test_gauge.values).to eq(
         { { gtag: :'gtag-value' } => 123 }
       )
+    end
+  end
+
+  context 'histogram' do
+    it do
       expect(Yabeda.test_histogram.values).to eq(
         { { htag: :'htag-value' } => 7 }
       )

--- a/spec/yabeda/prometheus/mmap_spec.rb
+++ b/spec/yabeda/prometheus/mmap_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe Yabeda::Prometheus::Mmap do
       gauge :gauge,
             comment: 'Gauge',
             tags: [:gtag],
-            aggregation: :max
+            aggregation: :sum
 
       histogram :histogram,
                 comment: 'Histogram',
@@ -49,7 +49,7 @@ RSpec.describe Yabeda::Prometheus::Mmap do
         .adapters[:prometheus].registry
         .instance_variable_get(:@metrics)[:test_gauge]
         .instance_variable_get(:@multiprocess_mode)
-      ).to eq(:max)
+      ).to eq(:livesum)
     end
   end
 


### PR DESCRIPTION
I noticed that the `aggregation`-parameter for gauges did nothing in a multi-process setting (the `pid`-attribute was still present). This PR should fix that.